### PR TITLE
Add .li RDAP server override

### DIFF
--- a/whoisit/overrides.py
+++ b/whoisit/overrides.py
@@ -21,7 +21,10 @@ iana_overrides = {
         'edu.gl': ['https://rdap.centralnic.com/edu.gl/'],
         'gov.gl': ['https://rdap.centralnic.com/gov.gl/'],
         'net.gl': ['https://rdap.centralnic.com/net.gl/'],
-        'org.gl': ['https://rdap.centralnic.com/org.gl/']
+        'org.gl': ['https://rdap.centralnic.com/org.gl/'],
+
+        # 2023-08-21 - .li has an RDAP endpoint it's just not listed
+        'li': ['https://rdap.nic.li/'],
 
     }
 


### PR DESCRIPTION
Add override for .li:

```
>>> import whoisit
>>> whoisit.bootstrap(overrides=True)
True
>>> whoisit.domain('nic.li')
{'handle': 'NIC.LI', 'parent_handle': '', 'name': 'nic.li', 'whois_server': '', 'type': 'domain', 'terms_of_service_url': '', 'copyright_notice': '', 'description': [], 'last_changed_date': None, 'registration_date': None, 'expiration_date': None, 'url': '', 'rir': '', 'entities': {'registrar': [{'url': 'https://gandi.net', 'type': 'entity', 'name': 'Gandi SAS'}]}, 'nameservers': [], 'status': ['inactive'], 'dnssec': False}
```