### PR TITLE
Add Identity Digital-hosted ccTLDs to overrides

### DIFF
--- a/whoisit/overrides.py
+++ b/whoisit/overrides.py
@@ -29,6 +29,18 @@ iana_overrides = {
         # 2023-09-05 - .nl has an RDAP endpoint it's just not listed
         'nl': ['https://rdap.sidn.nl/'],
 
+        # 2023-12-13 - the Identity Digital RDAP server appears to support these ccTLDs
+        'ac': ['https://rdap.identitydigital.services/'],
+        'ag': ['https://rdap.identitydigital.services/'],
+        'bz': ['https://rdap.identitydigital.services/'],
+        'io': ['https://rdap.identitydigital.services/'],
+        'lc': ['https://rdap.identitydigital.services/'],
+        'me': ['https://rdap.identitydigital.services/'],
+        'mn': ['https://rdap.identitydigital.services/'],
+        'pr': ['https://rdap.identitydigital.services/'],
+        'sc': ['https://rdap.identitydigital.services/'],
+        'sh': ['https://rdap.identitydigital.services/'],
+        'vc': ['https://rdap.identitydigital.services/'],
     }
 
 }


### PR DESCRIPTION
I noticed these today, which aren't listed in the IANA bootstrap file, but nonetheless got successful responses from the Identity Digital RDAP server.