### PR TITLE
Add override for '.co'

### DIFF
--- a/whoisit/overrides.py
+++ b/whoisit/overrides.py
@@ -41,6 +41,9 @@ iana_overrides = {
         'sc': ['https://rdap.identitydigital.services/rdap/'],
         'sh': ['https://rdap.identitydigital.services/rdap/'],
         'vc': ['https://rdap.identitydigital.services/rdap/'],
+
+        # 2024-05-03 - .co has an RDAP endpoint it's just not listed
+        'co': ['https://rdap.nic.co/'],
     }
 
 }


### PR DESCRIPTION
The `.co` registry doesn't show up in the IANA list, but has an active RDAP service.