### PR TITLE
Add entity address parser

### DIFF
--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -58,7 +58,16 @@ class ParserTestCase(unittest.TestCase):
                     'type': 'entity',
                     'whois_server': 'whois.arin.net',
                     'name': 'Cloudflare, Inc.',
-                    'rir': 'arin'
+                    'rir': 'arin',
+                    'address': {
+                        'po_box': '',
+                        'ext_address': '',
+                        'street_address': '',
+                        'locality': '',
+                        'region': '',
+                        'postal_code': '',
+                        'country': '',
+                    }
                 }
             ]
         )
@@ -72,7 +81,16 @@ class ParserTestCase(unittest.TestCase):
                     'name': 'Abuse',
                     'email': 'abuse@cloudflare.com',
                     'tel': '+1-650-319-8930',
-                    'rir': 'arin'
+                    'rir': 'arin',
+                    'address': {
+                        'po_box': '',
+                        'ext_address': '',
+                        'street_address': '',
+                        'locality': '',
+                        'region': '',
+                        'postal_code': '',
+                        'country': '',
+                    }
                 }
             ]
         )
@@ -86,7 +104,16 @@ class ParserTestCase(unittest.TestCase):
                     'name': 'NOC',
                     'email': 'noc@cloudflare.com',
                     'tel': '+1-650-319-8930',
-                    'rir': 'arin'
+                    'rir': 'arin',
+                    'address': {
+                        'po_box': '',
+                        'ext_address': '',
+                        'street_address': '',
+                        'locality': '',
+                        'region': '',
+                        'postal_code': '',
+                        'country': '',
+                    }
                 }
             ]
         )
@@ -100,7 +127,16 @@ class ParserTestCase(unittest.TestCase):
                     'name': 'Admin',
                     'email': 'rir@cloudflare.com',
                     'tel': '+1-650-319-8930',
-                    'rir': 'arin'
+                    'rir': 'arin',
+                    'address': {
+                        'po_box': '',
+                        'ext_address': '',
+                        'street_address': '',
+                        'locality': '',
+                        'region': '',
+                        'postal_code': '',
+                        'country': '',
+                    }
                 }
             ]
         )
@@ -176,7 +212,16 @@ class ParserTestCase(unittest.TestCase):
                     'url': 'https://rdap.norid.no/entity/reg42-NORID',
                     'type': 'entity',
                     'name': 'Domeneshop AS',
-                    'email': 'kundeservice@domeneshop.no'
+                    'email': 'kundeservice@domeneshop.no',
+                    'address': {
+                        'po_box': '',
+                        'ext_address': '',
+                        'street_address': 'Christian Krohgs gate 16',
+                        'locality': 'Oslo',
+                        'region': '',
+                        'postal_code': 'NO-0186',
+                        'country': 'NORWAY',
+                    }
                 }
             ]
         )
@@ -187,7 +232,16 @@ class ParserTestCase(unittest.TestCase):
                     'url': 'https://rdap.norid.no/entity/DH21326R-NORID',
                     'type': 'entity',
                     'name': 'Domeneshop Hostmaster',
-                    'email': 'hostmaster@domeneshop.no'
+                    'email': 'hostmaster@domeneshop.no',
+                    'address': {
+                        'po_box': '',
+                        'ext_address': '',
+                        'street_address': '',
+                        'locality': '',
+                        'region': '',
+                        'postal_code': '',
+                        'country': 'NORWAY',
+                    }
                 }
             ]
         )
@@ -210,7 +264,7 @@ class ParserTestCase(unittest.TestCase):
                 {
                     'handle': '1647',
                     'type': 'entity',
-                    'name': 'Hosting Concepts B.V. d/b/a Registrar.eu',
+                    'name': 'Hosting Concepts B.V. d/b/a Registrar.eu'
                 }
             ]
         )
@@ -255,7 +309,16 @@ class ParserTestCase(unittest.TestCase):
                     'name': 'APNIC RESEARCH',
                     'email': 'research@apnic.net',
                     'tel': '+61-7-3858-3199',
-                    'rir': 'apnic'
+                    'rir': 'apnic',
+                    'address': {
+                        'po_box': '',
+                        'ext_address': '',
+                        'street_address': '',
+                        'locality': '',
+                        'region': '',
+                        'postal_code': '',
+                        'country': '',
+                    }
                 }
             ]
         )
@@ -315,7 +378,16 @@ class ParserTestCase(unittest.TestCase):
                     'name': 'APNIC RESEARCH',
                     'email': 'research@apnic.net',
                     'tel': '+61-7-3858-3199',
-                    'rir': 'apnic'
+                    'rir': 'apnic',
+                    'address': {
+                        'po_box': '',
+                        'ext_address': '',
+                        'street_address': '',
+                        'locality': '',
+                        'region': '',
+                        'postal_code': '',
+                        'country': '',
+                    }
                 }
             ]
         )
@@ -348,7 +420,16 @@ class ParserTestCase(unittest.TestCase):
                     'rir': 'arin',
                     'type': 'entity',
                     'url': 'https://rdap.arin.net/registry/entity/GOGL',
-                    'whois_server': 'whois.arin.net'
+                    'whois_server': 'whois.arin.net',
+                    'address': {
+                        'po_box': '',
+                        'ext_address': '',
+                        'street_address': '',
+                        'locality': '',
+                        'region': '',
+                        'postal_code': '',
+                        'country': '',
+                    }
                 }
             ]
         )
@@ -362,7 +443,16 @@ class ParserTestCase(unittest.TestCase):
                     'type': 'entity',
                     'url': 'https://rdap.arin.net/registry/entity/ZG39-ARIN',
                     'tel': '+1-650-253-0000',
-                    'whois_server': 'whois.arin.net'
+                    'whois_server': 'whois.arin.net',
+                    'address': {
+                        'po_box': '',
+                        'ext_address': '',
+                        'street_address': '',
+                        'locality': '',
+                        'region': '',
+                        'postal_code': '',
+                        'country': '',
+                    }
                 }
             ]
         )
@@ -376,7 +466,16 @@ class ParserTestCase(unittest.TestCase):
                     'type': 'entity',
                     'url': 'https://rdap.arin.net/registry/entity/ZG39-ARIN',
                     'tel': '+1-650-253-0000',
-                    'whois_server': 'whois.arin.net'
+                    'whois_server': 'whois.arin.net',
+                    'address': {
+                        'po_box': '',
+                        'ext_address': '',
+                        'street_address': '',
+                        'locality': '',
+                        'region': '',
+                        'postal_code': '',
+                        'country': '',
+                    }
                 }
             ]
         )
@@ -390,7 +489,16 @@ class ParserTestCase(unittest.TestCase):
                     'name': 'Abuse',
                     'email': 'network-abuse@google.com',
                     'tel': '+1-650-253-0000',
-                    'rir': 'arin'
+                    'rir': 'arin',
+                    'address': {
+                        'po_box': '',
+                        'ext_address': '',
+                        'street_address': '',
+                        'locality': '',
+                        'region': '',
+                        'postal_code': '',
+                        'country': '',
+                    }
                 },
                 {
                     'handle': 'ZG39-ARIN',
@@ -400,7 +508,16 @@ class ParserTestCase(unittest.TestCase):
                     'name': 'Google LLC',
                     'email': 'arin-contact@google.com',
                     'tel': '+1-650-253-0000',
-                    'rir': 'arin'
+                    'rir': 'arin',
+                    'address': {
+                        'po_box': '',
+                        'ext_address': '',
+                        'street_address': '',
+                        'locality': '',
+                        'region': '',
+                        'postal_code': '',
+                        'country': '',
+                    }
                 }
             ]
         )
@@ -432,7 +549,16 @@ class ParserTestCase(unittest.TestCase):
                     'rir': 'arin',
                     'type': 'entity',
                     'url': 'https://rdap.arin.net/registry/entity/GOGL',
-                    'whois_server': 'whois.arin.net'
+                    'whois_server': 'whois.arin.net',
+                    'address': {
+                        'po_box': '',
+                        'ext_address': '',
+                        'street_address': '',
+                        'locality': '',
+                        'region': '',
+                        'postal_code': '',
+                        'country': '',
+                    }
                 }
             ]
         )
@@ -464,7 +590,16 @@ class ParserTestCase(unittest.TestCase):
                     'type': 'entity',
                     'url': 'https://rdap.arin.net/registry/entity/GTS7-ARIN',
                     'tel': '+1-519-254-5115',
-                    'whois_server': 'whois.arin.net'
+                    'whois_server': 'whois.arin.net',
+                    'address': {
+                        'po_box': '',
+                        'ext_address': '',
+                        'street_address': '',
+                        'locality': '',
+                        'region': '',
+                        'postal_code': '',
+                        'country': '',
+                    }
                 }
             ]
         )

--- a/tests/test_public_interface.py
+++ b/tests/test_public_interface.py
@@ -91,6 +91,17 @@ class SyncPublicInterfaceTestCase(unittest.TestCase):
         )
         self.assertTrue(isinstance(resp["entities"]["registrar"], list))
         self.assertTrue(len(resp["entities"]["registrar"]) > 0)
+        self.assertTrue(isinstance(resp["entities"]["registrant"], list))
+        self.assertTrue(len(resp["entities"]["registrant"]) > 0)
+        self.assertEqual(resp["entities"]["registrant"][0]['address'], {
+            'country': "US",
+            'ext_address': '',
+            'locality': '',
+            'po_box': '',
+            'postal_code': '',
+            'region': 'CA',
+            'street_address': '',
+        })
 
     @responses.activate
     # @_recorder.record(file_path=RESPONSES / 'ip-v4-1.yaml')
@@ -314,6 +325,17 @@ class AsyncPublicInterfaceTestCase(unittest.IsolatedAsyncioTestCase):
         )
         self.assertTrue(isinstance(resp["entities"]["registrar"], list))
         self.assertTrue(len(resp["entities"]["registrar"]) > 0)
+        self.assertTrue(isinstance(resp["entities"]["registrant"], list))
+        self.assertTrue(len(resp["entities"]["registrant"]) > 0)
+        self.assertEqual(resp["entities"]["registrant"][0]['address'], {
+            'country': "US",
+            'ext_address': '',
+            'locality': '',
+            'po_box': '',
+            'postal_code': '',
+            'region': 'CA',
+            'street_address': '',
+        })
 
     @pytest.mark.asyncio
     @pytest.mark.usefixtures("mock_httpx")

--- a/whoisit/parser.py
+++ b/whoisit/parser.py
@@ -5,7 +5,7 @@ from ipaddress import (
     IPv4Network,
     IPv6Network
 )
-from typing import Optional
+from typing import Optional, List
 from typing_extensions import TypedDict
 
 from dateutil.parser import parse as dateutil_parse
@@ -39,7 +39,7 @@ class VCardArrayDataDict(TypedDict, total=False):
     name: str
     email: str
     tel: str
-    address: list[str]
+    address: List[str]
 
 
 class VCardArrayAddressDataDict(TypedDict, total=False):

--- a/whoisit/parser.py
+++ b/whoisit/parser.py
@@ -118,13 +118,13 @@ class Parser:
                 v_card_array_data_dict["tel"] = clean(entry_label)
             elif entry_field == 'adr' and isinstance(entry_label, list) and len(entry_label) == 7:
                 v_card_array_data_dict['address'] = VCardArrayAddressDataDict(
-                    po_box= clean_address(entry_label[0]),
-                    ext_address= clean_address(entry_label[1]),
-                    street_address= clean_address(entry_label[2]),
-                    locality= clean_address(entry_label[3]),
-                    region= clean_address(entry_label[4]),
-                    postal_code= clean_address(entry_label[5]),
-                    country= clean_address(entry_label[6])
+                    po_box=clean_address(entry_label[0]),
+                    ext_address=clean_address(entry_label[1]),
+                    street_address=clean_address(entry_label[2]),
+                    locality=clean_address(entry_label[3]),
+                    region=clean_address(entry_label[4]),
+                    postal_code=clean_address(entry_label[5]),
+                    country=clean_address(entry_label[6])
                 )
 
         return v_card_array_data_dict or None

--- a/whoisit/parser.py
+++ b/whoisit/parser.py
@@ -25,10 +25,31 @@ def clean(s):
     return s.strip()
 
 
+def clean_address(a):
+    if a is None:
+        a = ''
+    if isinstance(a, list):
+        a = ' '.join(a)
+    if not isinstance(a, str):
+        a = str(a)
+    return a.strip()
+
+
 class VCardArrayDataDict(TypedDict, total=False):
     name: str
     email: str
     tel: str
+    address: list[str]
+
+
+class VCardArrayAddressDataDict(TypedDict, total=False):
+    po_box: str
+    ext_address: str
+    street_address: str
+    locality: str
+    region: str
+    postal_code: str
+    country: str
 
 
 class Parser:
@@ -95,6 +116,16 @@ class Parser:
                 v_card_array_data_dict["email"] = clean(entry_label)
             elif entry_field == 'tel':
                 v_card_array_data_dict["tel"] = clean(entry_label)
+            elif entry_field == 'adr' and isinstance(entry_label, list) and len(entry_label) == 7:
+                v_card_array_data_dict['address'] = VCardArrayAddressDataDict(
+                    po_box= clean_address(entry_label[0]),
+                    ext_address= clean_address(entry_label[1]),
+                    street_address= clean_address(entry_label[2]),
+                    locality= clean_address(entry_label[3]),
+                    region= clean_address(entry_label[4]),
+                    postal_code= clean_address(entry_label[5]),
+                    country= clean_address(entry_label[6])
+                )
 
         return v_card_array_data_dict or None
 


### PR DESCRIPTION
Add entity address parser. This handles vcard addresses in the array format. It does not handle the loose label style. Most of the tests show empty addresses, because thats how the test data is, but there are some good examples in there. Used format as defined in https://datatracker.ietf.org/doc/html/rfc7483#autoid-50

array format:

    ["adr",{},"text",["","","","","CA","","US"]]

label:

    ["adr", {"label": "3005 Deziel Drive\\nWindsor\\nON\\nN8W 5A5\\nCanada"}, "text", ["", "", "", "", "", "", ""]]