### PR TITLE
Parse non compliant v card adr label

### DIFF
--- a/whoisit/parser.py
+++ b/whoisit/parser.py
@@ -35,6 +35,39 @@ def clean_address(a):
     return a.strip()
 
 
+def clean_address_label(adr_label, max_size=7):
+    try:
+        # In cases where multiple address lines are present, such as
+        # when specifying a suite or floor number, the label
+        # configuration employs a carriage return and line feed
+        # ('\r\n') to separate these details.
+        parsed_address = adr_label.replace('\r\n', '; ').split('\n')
+
+        # Help ensure reliable results or none at all
+        if any('' == x or x.isspace() for x in parsed_address):
+            log.debug(f'Failed to parse non-compliant vCard adr: {repr(adr_label)}')
+            return [""] * max_size
+        elif len(parsed_address) > max_size:
+            log.debug(f'Failed to parse non-compliant vCard adr: {repr(adr_label)}')
+            return [""] * max_size
+        elif len(parsed_address) == 0:
+            log.debug(f'Failed to parse non-compliant vCard adr: {repr(adr_label)}')
+            return [""] * max_size
+
+        entry_label = [""] * max_size
+
+        # Calculate the starting index for insertion
+        i = len(entry_label) - len(parsed_address)
+
+        # Insert elements of parsed_address into entry_label starting
+        # from the calculated index
+        return entry_label[:i] + parsed_address + entry_label[i+len(parsed_address):]
+
+    except Exception as e:
+        log.exception(f'Exception "{e}" while parsing non-compliant vCard adr: {repr(adr_label)}')
+        return [""] * max_size
+
+
 class VCardArrayDataDict(TypedDict, total=False):
     name: str
     email: str
@@ -117,6 +150,9 @@ class Parser:
             elif entry_field == 'tel':
                 v_card_array_data_dict["tel"] = clean(entry_label)
             elif entry_field == 'adr' and isinstance(entry_label, list) and len(entry_label) == 7:
+                # Process non-compliant address label in vCard adr field
+                if 'label' in entry_data and all('' == x or x.isspace() for x in entry_label):
+                    entry_label = clean_address_label(entry_data['label'], max_size=len(entry_label))
                 v_card_array_data_dict['address'] = VCardArrayAddressDataDict(
                     po_box=clean_address(entry_label[0]),
                     ext_address=clean_address(entry_label[1]),

--- a/whoisit/parser.py
+++ b/whoisit/parser.py
@@ -64,7 +64,7 @@ def clean_address_label(adr_label, max_size=7):
         return entry_label[:i] + parsed_address + entry_label[i+len(parsed_address):]
 
     except Exception as e:
-        log.exception(f'Exception "{e}" while parsing non-compliant vCard adr: {repr(adr_label)}')
+        log.debug(f'Exception while parsing non-compliant vCard adr: {repr(adr_label)}')
         return [""] * max_size
 
 


### PR DESCRIPTION
## Pull Request Description

### Summary

This PR introduces a new function designed to clean and parse addresses that are stored in a non-compliant format within the vCard adr field. The goal is to enhance the user experience by providing address information even when it is not perfectly formatted, thereby reducing data loss.

### Details

#### Problem Statement
Previously, if an address was stored in a non-standard format, the system would simply discard it and provide no address information to the end-user. This resulted in lost opportunities for users to receive relevant address details.

#### Solution Overview
To address this issue, I have added a function called `clean_address_label`. This function takes an input string (the non-compliant address) and attempts to parse it into the standard format. If the parsing is successful, the cleaned address will be returned; otherwise, it returns a list of empty strings.

#### Functionality
- **Input:** A string representing an address in any format.
- **Output:** Either the parsed address list or a list of empty strings if parsing fails.

### Benefits

1. **Improved User Experience:** Users will receive more comprehensive address information even if data is stored in non-standard ways.
2. **Data Utilization:** Ensures that valuable but imperfectly formatted address data is not discarded, thus maximizing the utility of stored address data.

---

Feel free to review and provide feedback!

Best,
BeetleChunks